### PR TITLE
Updated Dockerfile to current NER version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,16 @@ RUN apt-get install -y \
     && apt-get clean  && \
     rm -rf /var/lib/apt/lists/*
 
-ADD http://nlp.stanford.edu/software/stanford-ner-2015-01-29.zip ner.zip
-RUN unzip ner.zip
+ENV STANFORD_NER_VERSION=stanford-ner-2018-02-27
 
-WORKDIR /stanford-ner-2015-01-30
+ADD "https://nlp.stanford.edu/software/${STANFORD_NER_VERSION}.zip" ner.zip
+# If we have the ner archive locally (dev), build from it to save time
+# ADD "${STANFORD_NER_VERSION}.zip" ner.zip
 
-ADD run.py run.py
+RUN unzip ner.zip && rm ner.zip
+WORKDIR "${STANFORD_NER_VERSION}"
 
-ENTRYPOINT ["python", "-u", "/stanford-ner-2015-01-30/run.py"]
+ADD run.py ./
+
+CMD ["python", "-u", "./run.py"]
 EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -35,3 +35,8 @@ Note that if you use OSX with boot2docker you will need to use `boot2docker ip` 
     $ docker run -d -p 4465:80 lawinsider/stanford-ner-docker
     $ curl "localhost?query=This%20Mortgage%20Loan%20Purchase%20Agreement,%20dated%20as%20of%20February%2025,%202015,%20is%20between%20J.P.%20Morgan%20Chase%20Commercial%20Mortgage%20Securities%20Corp.,%20as%20purchaser%20and%20Barclays%20Bank%20PLC,%20as%20seller."
     {"DATE": ["February 25, 2015"], "ORGANIZATION": ["J.P. Morgan Chase Commercial Mortgage Securities Corp.", "Barclays Bank PLC"]}
+
+## Deployment
+
+The image respects the `PORT` environment variable, making it suitable for deployment on most modern container hosts.
+

--- a/run.py
+++ b/run.py
@@ -15,7 +15,7 @@ from operator import itemgetter
 
 STANFORD_PARSER = os.path.abspath('stanford-ner.jar')
 STANFORD_MODEL = os.path.abspath(
-  'classifiers/english.all.7class.distsim.crf.ser.gz')
+  'classifiers/english.muc.7class.distsim.crf.ser.gz')
 SLASHTAGS_EPATTERN = re.compile(r'(.+?)/([A-Z]+)?\s*')
 XML_EPATTERN = re.compile(r'<wi num=".+?" entity="(.+?)">(.+?)</wi>')
 INLINEXML_EPATTERN = re.compile(r'<([A-Z]+?)>(.+?)</\1>')
@@ -165,8 +165,10 @@ if __name__ == '__main__':
   print 'Starting Stanford NER TCP server...'
   start_ner_server(STANFORD_PARSER, STANFORD_MODEL)
   print 'Starting HTTP proxy server...'
+  port = int(os.environ.get('PORT', '80'))
+  print 'Listening on port %s...' % port
   try:
-    server = BaseHTTPServer.HTTPServer(('0.0.0.0', 80), HttpHandler)
+    server = BaseHTTPServer.HTTPServer(('0.0.0.0', port), HttpHandler)
     server.serve_forever()
   except KeyboardInterrupt:
     print('Stopping NER server..')


### PR DESCRIPTION
Thanks for packing this up into a Docker image initially.

This PR:
- updates the internal Stanford NER version
- generalises the Dockerfile for future updates
- updates `run.py` to respect the common hosting environment variable `PORT`

These updates have been built and released here:
https://hub.docker.com/r/tommilligan/stanford-ner-docker/